### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/fit-to-width.php
+++ b/fit-to-width.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:       Fit To Width
  * Description:       A text block where each line is automatically full width.
- * Version:           0.1.0
+ * Version:           0.2.0
  * Requires at least: 6.7
  * Requires PHP:      7.4
  * Author:            Kevin Batdorf

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82
 Tags:              block, responsive text, stretchy, typography, creative
 Tested up to:      7.0
-Stable tag:        0.1.0
+Stable tag:        0.2.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -46,6 +46,11 @@ There are arguments that if you maintain a width legible enough then zooming may
 1. An example of the text next to a cool dog
 
 == Changelog ==
+
+= 0.2.0 - 2026-04-12 =
+- Modernize tooling: Biome, Playwright + WP Playground, updated deps.
+- Update CI workflows to use node lts/*.
+- Tested up to WordPress 7.0.
 
 = 0.1.0 =
 - Initial Release


### PR DESCRIPTION
## Summary
- Bump plugin version from 0.1.0 to 0.2.0 in `fit-to-width.php` and `readme.txt`.
- Add changelog entry for the tooling modernization (Biome, Playwright + WP Playground, updated CI).

## Test plan
- [ ] Verify version displays correctly in WordPress plugin list.
- [ ] Confirm readme.txt parses correctly on wordpress.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)